### PR TITLE
Beautify the theme

### DIFF
--- a/assets/ananke/css/cus_page.scss
+++ b/assets/ananke/css/cus_page.scss
@@ -1,0 +1,171 @@
+@import "cus_var.scss";
+
+#article-body {
+	position: relative;
+
+	// TODO: responsive
+	#toc {
+		display: none;
+	}
+	@media screen and (min-width: 98rem) {
+		#toc {
+			display: block;
+			float: left;
+			position: absolute;
+			top: 0;
+			left: calc( 100% + 1rem );
+		}
+	}
+	#toc {
+		padding: 0 5px;
+		background-color: var(--bg-lesss);
+		width: 16rem;
+		box-sizing: border-box;
+		>div #TableOfContents {
+			ul {
+				padding-left: 0;
+			}
+			li {
+				margin-bottom: 0;
+				padding: 0;
+				display: flex;
+				flex-direction: column;
+				p {
+					margin: 0;
+					padding: 0;
+				}
+				a {
+					z-index: 10;
+					display: block;
+					position: relative;
+					width: 100%;
+					line-height: 1em;
+					padding: 0.5em 1em 0.5em 0;
+					box-sizing: border-box;
+					text-decoration: none;
+					color: var(--fg);
+					&:before {
+						content: ' ';
+						position: absolute;
+						top: 0;
+						left: 0;
+						display: inline-block;
+						width: 10px;
+						height: 100%;
+						border-right: 1px solid var(--brand-lighten);
+						transition: border-right-color 0.3s;
+					}
+					&:hover {
+						&:after {
+							content: ' ';
+							position: absolute;
+							z-index: -1;
+							top: 0;
+							left: 0;
+							width: 100%;
+							height: 100%;
+							background-color: var(--brand-lighten);
+							transition: background-color 0.3s;
+							opacity: 0.8;
+						}
+					}
+					&.active {
+						&:before {
+							border-right-color: var(--brand);
+						}
+					}
+				}
+			}
+			>ul {
+				list-style: none;
+				padding-left: 0;
+				position: relative;
+				>li {
+					position: relative;
+					a {
+						padding-left: 30px;
+					}
+					>ul>li {
+						a {
+							padding-left: 50px;
+						}
+						>ul>li {
+							a {
+								padding-left: 70px;
+							}
+							>ul>li {
+								a {
+									padding-left: 90px;
+								}
+								>ul>li {
+									a {
+										padding-left: 110px;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// article main content
+	>div {
+		h1,h2 {
+			border-bottom: 1px solid var(--bg-less);
+		}
+		h1,h2,h3,h4,h5,h6,h7,h8,h9 {
+			position: relative;
+			.hanchor {
+				position: relative;
+				left: 0.5em;
+				bottom: 0.2em;
+				font-size: 0.6em;
+				display: inline-block;
+				transition: opacity 0.3s;
+				opacity: 0;
+			}
+			a {
+				text-decoration: none;
+				color: inherit;
+			}
+			&:hover {
+				.hanchor {
+					transition: opacity 0.3s;
+					opacity: 0.5;
+				}
+			}
+		}
+		table {
+			position: relative;
+			width: 100%;
+			max-width: 100%;
+			overflow: auto;
+			border: none;
+			border-spacing: 0;
+			border-top: 1px solid var(--fg-less);
+			border-right: 1px solid var(--fg-less);
+			break-inside: avoid-page;
+			th, td {
+				border-spacing: 0;
+				border-top: none;
+				border-right: none;
+				border-left: 1px solid var(--fg-less);
+				border-bottom: 1px solid var(--fg-less);
+				padding: 0.2em;
+			}
+			th {
+				border-bottom-width: 2px;
+			}
+			tr:nth-child(even) {
+				background-color: var(--bg-less);
+			}
+			p {
+				display: inline;
+				margin: 0;
+			}
+		}
+	}
+}
+

--- a/assets/ananke/css/cus_site.scss
+++ b/assets/ananke/css/cus_site.scss
@@ -1,0 +1,162 @@
+@import "cus_var.scss";
+
+body>header, body>footer {
+	>div {
+		background-color: transparent !important;
+	}
+	background-image: radial-gradient(
+		circle at 30% 10%,
+		rgba(231, 240, 253, 1),
+		rgba(233, 222, 250, 0.5) 80%
+		), radial-gradient(
+		circle at 60% 10%,
+		rgba(231, 240, 253, 1),
+		rgba(255, 241, 235, 0) 80%
+		), radial-gradient(
+		circle at 90% 10%,
+		rgba(166, 193, 238, 1),
+		rgba(255, 241, 235, 0) 80%
+		), radial-gradient(
+		circle at 0% 90%,
+		rgba(168, 237, 234, 0.8),
+		rgba(254, 214, 227, 0.3) 80%
+		), radial-gradient(
+		circle at 30% 90%,
+		rgba(168, 237, 234, 0.8),
+		rgba(254, 214, 227, 0.3) 80%
+		), radial-gradient(
+		circle at 60% 90%,
+		rgba(168, 237, 234, 0.8),
+		rgba(254, 214, 227, 0.3) 100%
+		);;
+	--this-color: #888;
+	color: var(--this-color);
+	.light-silver {
+		color: var(--this-color);
+	}
+
+	a {
+		color: var(--link-color-grey);
+		text-decoration: none;
+		&:hover {
+			color: var(--link-color-grey);
+			text-decoration: underline;
+		}
+	}
+
+	.ananke-socials a {
+		color: var(--link-color-grey);
+		&:hover {
+			color: var(--link-color-grey) !important;
+		}
+	}
+}
+
+body>header {
+	padding-top: var(--sat) !important;
+	padding-right: var(--sar) !important;
+	padding-left: var(--sal) !important;
+
+	h1 {
+		text-shadow: 1px 1px 2px #FFFFFFE0;
+	}
+
+	a {
+		font-size: 0.8em;
+	}
+
+	@media screen and (min-width: 30em) {
+		.ph4-ns {
+			padding-left: 4rem;
+			padding-right: 4rem;
+		}
+	}
+
+	&.bg-top nav a.dib {
+		text-shadow: 0 0 white;
+	}
+
+	nav {
+		a.i18n-link {
+			font-size: 0.6em;
+		}
+		a.dib {
+			&:hover {
+				text-decoration: none;
+			}
+		}
+
+		div.ananke-socials {
+			display: none;
+		}
+
+		@media screen and (min-width: 60em) {
+			div.ananke-socials {
+				display: block;
+			}
+			a.i18n-link {
+				font-size: 1em;
+			}
+		}
+	}
+
+}
+
+body>main {
+	// TODO: migrate with margin of the 'article' element
+	margin-left: var(--sal) !important;
+	margin-right: var(--sar) !important;
+
+	&.pb7 {
+		padding-bottom: 8rem;
+	}
+}
+
+body>footer {
+	padding-right: calc(var(--sar) + 1rem) !important;
+	padding-bottom: calc(var(--sab) + 1rem) !important;
+	padding-left: calc(var(--sal) + 1rem) !important;
+
+	div.ananke-socials {
+		display: inline-block;
+	}
+
+	@media screen and (min-width: 60em) {
+		div.ananke-socials {
+			display: none;
+		}
+	}
+}
+
+article.summary .summary-body {
+	&:after {
+		content: "...";
+		color: var(--fg-lesss);
+	}
+}
+
+body>main section.more {
+	h2 {
+		display: block;
+		color: var(--fg-less);
+		font-weight: normal;
+		font-size: 1em;
+	}
+
+	ul {
+		list-style: none;
+		padding: 0;
+		li {
+			margin-bottom: 0.5em;
+		}
+	}
+
+	a {
+		color: var(--link-color-grey);
+		text-decoration: none;
+		&:hover {
+			color: var(--link-color-grey);
+			text-decoration: underline;
+		}
+	}
+}

--- a/assets/ananke/css/cus_site.scss
+++ b/assets/ananke/css/cus_site.scss
@@ -1,5 +1,9 @@
 @import "cus_var.scss";
 
+.disabled-link {
+	pointer-events: none;
+}
+
 body>header, body>footer {
 	>div {
 		background-color: transparent !important;
@@ -96,6 +100,56 @@ body>header {
 			}
 			a.i18n-link {
 				font-size: 1em;
+			}
+		}
+	}
+
+	>div {
+		padding-bottom: 1px;
+	}
+
+	#registration {
+		margin-top: 5em;
+		margin-bottom: 2em;
+		a {
+			color: #F0F0F0;
+			display: inline-block;
+			padding: 0.8em 2em;
+			border-radius: 0.5em;
+			font-size: 2em;
+			font-weight: bold;
+			background-color: var(--bg-lesss);
+			background-image: linear-gradient(62deg, #8EC5FC 0%, #E0C3FC 100%);
+
+
+			transition: box-shadow .08s linear;
+			box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+			&:hover {
+				text-decoration: none;
+				transition: box-shadow .08s linear;
+				box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+			}
+
+			&.disabled-link {
+				color: var(--fg-lesss);
+				font-weight: 300;
+				box-shadow: none;
+				background-image: none;
+			}
+
+			span {
+				padding-left: 0.5em;
+				font-size: 90%;
+				font-weight: 300;
+			}
+		}
+	}
+
+	@media screen and (max-width: 60em) {
+		#registration {
+			margin-top: 3em;
+			a {
+				font-size: 1.5em;
 			}
 		}
 	}

--- a/assets/ananke/css/cus_var.scss
+++ b/assets/ananke/css/cus_var.scss
@@ -1,0 +1,27 @@
+:root {
+	--sat: env(safe-area-inset-top, 0px);
+	--sar: env(safe-area-inset-right, 0px);
+	--sab: env(safe-area-inset-bottom, 0px);
+	--sal: env(safe-area-inset-left, 0px);
+}
+
+::selection {
+	background-color: var(--highlight);
+}
+
+
+body {
+	--fg:       #232323;
+	--fg-less:  #616161;
+	--fg-lesss: #919191;
+
+	--bg-less:  #EAEAEA;
+	--bg-lesss: #F2F2F2;
+
+	--brand:             #FF6300;
+	--brand-lighten:     color-mix(in srgb, var(--brand) 80%, white);
+
+	--link-color-grey: #999;
+
+	--highlight: #FFDF88FE
+}

--- a/hugo.toml
+++ b/hugo.toml
@@ -9,6 +9,30 @@ pluralizeListTitles            = false
 defaultContentLanguage         = 'zh'
 defaultContentLanguageInSubdir = false
 
+#
+# Uncomment the below configuration if a common/fallback featured image is
+# necessary, the image should be copied to the 'static/images/' directory.
+#[cascade]
+#  featured_image = 'images/<the-name>.jpg'
+#
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      # Although it shows "unsafe", for this project anyone with document
+      # editing privileges also has configuration file editing privileges, so
+      # just pay more attention to the html code in the markdown. This will help
+      # you to customise the style of the article to a greater extent.
+      unsafe = true
+
+[params]
+  author = ''
+  recent_posts_number = 10
+  background_color_class = 'bg-orange'
+  custom_css = ["cus_page.scss", "cus_site.scss"]
+  [[params.ananke_socials]]
+    name = 'github'
+    url = 'https://github.com/plctlab/rvspoc'
 
 [permalinks]
   [permalinks.page]
@@ -25,6 +49,8 @@ defaultContentLanguageInSubdir = false
     languageName = '简体中文'
     title = 'RISC-V 软件移植及优化锦标赛'
     weight = 1
+    hasCJKLanguage = true
+    summaryLength = 230
   [languages.en]
     contentDir = 'content/en'
     disabled = false
@@ -49,6 +75,8 @@ defaultContentLanguageInSubdir = false
     languageName = '日本語'
     title = 'RISC-V ソフトウェアの移植と最適化チャンピオンシップ'
     weight = 4
+    hasCJKLanguage = true
+    summaryLength = 230
   [languages.ko]
     contentDir = 'content/ko'
     disabled = false
@@ -57,3 +85,5 @@ defaultContentLanguageInSubdir = false
     languageName = '한국어'
     title = 'RISC-V 소프트웨어포팅및최적화챔피언십'
     weight = 5
+    hasCJKLanguage = true
+    summaryLength = 230

--- a/hugo.toml
+++ b/hugo.toml
@@ -27,6 +27,11 @@ defaultContentLanguageInSubdir = false
 
 [params]
   author = ''
+
+  # Please uncomment and set the below registration_url on the eve of Dec 1st,
+  # it's the switch to enable the registration link on the homepage.
+  #registration_url = ''
+
   recent_posts_number = 10
   background_color_class = 'bg-orange'
   custom_css = ["cus_page.scss", "cus_site.scss"]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,12 @@
+[CC-BY-NC-SA-License-prefix]
+other = 'Except where otherwise noted , content on this site is licensed under a '
+
+[CC-BY-NC-SA-License]
+other = 'Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International license'
+
+[CC-BY-NC-SA-License-suffix]
+other = '.'
+
+[toc]
+other = 'Table of Contents'
+

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -10,3 +10,8 @@ other = '.'
 [toc]
 other = 'Table of Contents'
 
+[registration_desc]
+other = 'Registration'
+
+[registration_desc_suffix]
+other = '(Enabled on Dec 1st)'

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -1,0 +1,11 @@
+[CC-BY-NC-SA-License-prefix]
+other = 'Except where otherwise noted , content on this site is licensed under a '
+
+[CC-BY-NC-SA-License]
+other = 'Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International license'
+
+[CC-BY-NC-SA-License-suffix]
+other = '.'
+
+[toc]
+other = 'Table of Contents'

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -9,3 +9,9 @@ other = '.'
 
 [toc]
 other = 'Table of Contents'
+
+[registration_desc]
+other = 'Registration'
+
+[registration_desc_suffix]
+other = '(Enabled on Dec 1st)'

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -1,0 +1,67 @@
+[more]
+other = "More"
+
+[allTitle]
+other = "All {{.Title }}"
+
+[recentTitle]
+other = "Recent {{.Title }}"
+
+[readMore]
+other = "read more"
+
+[by]
+other = "By"
+
+[whatsInThis]
+other = "What's in this {{ .Type }}"
+
+[related]
+other = "Related"
+
+[yourName]
+other = "Your Name"
+
+[emailAddress]
+other = "Email Address"
+
+[message]
+other = "Message"
+
+[emailRequiredNote]
+other = "An email address is required."
+
+[send]
+other = "Send"
+
+[taxonomyPageList]
+other = "Below you will find pages that utilize the taxonomy term “{{ .Title }}”"
+
+[readingTime]
+one = "One minute read"
+other = "{{ .Count }} minutes read"
+
+[wordCount]
+one = "One word"
+other = "{{ .Count }} words"
+
+[pageTitle]
+other = "{{ .Name }} page"
+
+###
+# the above items are copied from theme ananke, path: themes/ananke/i18n/en.toml
+###
+###
+
+
+[CC-BY-NC-SA-License-prefix]
+other = 'Except where otherwise noted , content on this site is licensed under a '
+
+[CC-BY-NC-SA-License]
+other = 'Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International license'
+
+[CC-BY-NC-SA-License-suffix]
+other = '.'
+
+[toc]
+other = 'Table of Contents'

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -65,3 +65,9 @@ other = '.'
 
 [toc]
 other = 'Table of Contents'
+
+[registration_desc]
+other = 'Registration'
+
+[registration_desc_suffix]
+other = '(Enabled on Dec 1st)'

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -1,0 +1,11 @@
+[CC-BY-NC-SA-License-prefix]
+other = 'Except where otherwise noted , content on this site is licensed under a '
+
+[CC-BY-NC-SA-License]
+other = 'Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International license'
+
+[CC-BY-NC-SA-License-suffix]
+other = '.'
+
+[toc]
+other = 'Table of Contents'

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -9,3 +9,9 @@ other = '.'
 
 [toc]
 other = 'Table of Contents'
+
+[registration_desc]
+other = 'Registration'
+
+[registration_desc_suffix]
+other = '(Enabled on Dec 1st)'

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -1,0 +1,11 @@
+[CC-BY-NC-SA-License-prefix]
+other = '除另有说明外，本网站内容采用'
+
+[CC-BY-NC-SA-License]
+other = '知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议'
+
+[CC-BY-NC-SA-License-suffix]
+other = '进行许可。'
+
+[toc]
+other = '目录'

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -9,3 +9,9 @@ other = '进行许可。'
 
 [toc]
 other = '目录'
+
+[registration_desc]
+other = '报名入口'
+
+[registration_desc_suffix]
+other = '（12 月 1 日启动）'

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,70 @@
+{{ define "header" }}
+   {{/* We can override any block in the baseof file be defining it in the template */}}
+  {{ partial "page-header.html" . }}
+{{ end }}
+
+{{ define "main" }}
+  {{ $section := .Site.GetPage "section" .Section }}
+  <article class="justify-between mw8 center ph3">
+    <header class="mt4 w-100">
+      {{ partial "social-share.html" . }}
+      <h1 class="f1 athelas mt3 mb1">
+        {{- .Title -}}
+      </h1>
+      {{ with .Params.author | default .Site.Params.author }}
+      <p class="tracked">
+        {{ $.Render "by" }} <strong>
+        {{- if reflect.IsSlice . -}}
+            {{ delimit . ", " | markdownify }}
+        {{- else -}}
+            {{ . | markdownify }}
+        {{- end -}}
+        </strong>
+      </p>
+      {{ end }}
+      {{/* Hugo uses Go's date formatting is set by example. Here are two formats */}}
+      {{ if not .Date.IsZero }}
+      <time class="f6 mv4 dib tracked" {{ printf `datetime="%s"` (.Date.Format "2006-01-02T15:04:05Z07:00") | safeHTMLAttr }}>
+        {{- .Date | time.Format (default "January 2, 2006" .Site.Params.date_format) -}}
+      </time>
+      {{end}}
+
+      {{/*
+          Show "reading time" and "word count" but only if one of the following are true:
+          1) A global config `params` value is set `show_reading_time = true`
+          2) A section front matter value is set `show_reading_time = true`
+          3) A page front matter value is set `show_reading_time = true`
+        */}}
+      {{ if (or (eq (.Param "show_reading_time") true) (eq $section.Params.show_reading_time true) )}}
+        <span class="f6 mv4 dib tracked"> - {{ i18n "readingTime" .ReadingTime }} </span>
+        <span class="f6 mv4 dib tracked"> - {{ i18n "wordCount" .WordCount }} </span>
+      {{ end }}
+    </header>
+    <div id="article-body">
+      <div class="nested-copy-line-height lh-copy {{ $.Param "post_content_classes"  | default "serif"}} f4 nested-links {{ $.Param "text_color" | default "mid-gray" }}">
+        {{- with .Content -}}
+        <div>
+          {{ . | replaceRE "(<h[1-9] id=\"([^\"]+)\".+)(</h[1-9]+>)" `${1}<a href="#${2}" class="hanchor">🔗</a>${3}` | safeHTML }}
+        </div>
+        {{- end -}}
+        {{- partial "tags.html" . -}}
+        <div class="mt6 instapaper_ignoref">
+        {{ if .Site.Params.commentoEnable }}
+          {{- partial "commento.html" . -}}
+        {{ end }}
+        </div>
+      </div>
+
+      {{- if .Params.toc -}}
+      <aside id="toc" class="f6">
+        <div class="">
+          <p class="f5 b mb3">{{ i18n "toc" . }}</p>
+            {{ .TableOfContents }}
+        </div>
+      </aside>
+      {{- end -}}
+    </div>
+
+
+  </article>
+{{ end }}

--- a/layouts/_default/summary-with-image.html
+++ b/layouts/_default/summary-with-image.html
@@ -1,0 +1,28 @@
+{{ $featured_image := partial "func/GetFeaturedImage.html" . }}
+<article class="summary bb b--black-10">
+  <div class="db pv4 ph3 ph0-l no-underline dark-gray">
+    <div class="flex flex-column flex-row-ns">
+      <div class="datetime-block">
+        {{- .Date | time.Format (default "January 2, 2006" .Site.Params.date_format) -}}
+      </div>
+      {{ if $featured_image }}
+          {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
+        <div class="{{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl3-ns" "pr3-ns" }} mb4 mb0-ns w-100 w-40-ns">
+          <a href="{{.RelPermalink}}" class="db grow">
+            <img src="{{ $featured_image }}" class="img" alt="image from {{ .Title }}">
+          </a>
+        </div>
+      {{ end }}
+      <div class="blah w-100{{ if $featured_image }} w-60-ns {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pr3-ns" "pl3-ns" }}{{ end }}">
+        <h1 class="f3 fw1 athelas mt0 lh-title">
+          <a href="{{.RelPermalink}}" class="color-inherit dim link">
+            {{ .Title }}
+            </a>
+        </h1>
+        <div class="summary-body f6 f5-l lh-copy nested-copy-line-height nested-links">
+          {{ .Summary }}
+        </div>
+      </div>
+    </div>
+  </div>
+</article>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,50 @@
+{{ define "main" }}
+  <article class="cf ph3 ph5-l pv3 pv4-l f4 tc-l center measure-wide lh-copy {{ $.Param "text_color" | default "mid-gray" }}">
+    {{ .Content }}
+  </article>
+  {{/* Define a section to pull recent posts from. For Hugo 0.20 this will default to the section with the most number of pages. */}}
+  {{ $mainSections := .Site.Params.mainSections | default (slice "post") }}
+  {{/* Create a variable with that section to use in multiple places. */}}
+  {{ $section := where .Site.RegularPages "Section" "in" $mainSections }}
+  {{/* Check to see if the section is defined for ranging through it */}}
+  {{ $section_count := len $section }}
+  {{ if ge $section_count 1 }}
+    {{/* Derive the section name  */}}
+    {{ $section_name := index (.Site.Params.mainSections) 0 }}
+
+    <div class="pa3 w-100 mw8 center">
+      {{ $n_posts := $.Param "recent_posts_number" | default 3 }}
+
+      <section class="w-100 mw8">
+        {{/* Range through the first $n_posts items of the section */}}
+        {{ range (first $n_posts $section) }}
+          <div class="relative w-100 mb4">
+            {{ .Render "summary-with-image" }}
+          </div>
+        {{ end }}
+      </section>
+
+      {{ if ge $section_count (add $n_posts 1) }}
+      <section class="more w-100">
+        <h2 class="f3">{{ i18n "more" }}:</h2>
+        {{/* Now, range through the next four after the initial $n_posts items. Nest the requirements, "after" then "first" on the outside */}}
+        <ul>
+        {{ range (first 5 (after $n_posts $section))  }}
+          <li class="f5">
+            <a href="{{ .RelPermalink }}" class="link black dim">
+              {{ .Title }}
+            </a>
+          </li>
+        {{ end }}
+        </ul>
+
+        {{/* As above, Use $section_name to get the section title, and URL. Use "with" to only show it if it exists */}}
+        {{ with .Site.GetPage "section" $section_name }}
+          <a href="{{ .RelPermalink }}" class="f6">{{ i18n "allTitle" . }}</a>
+        {{ end }}
+        </section>
+      {{ end }}
+
+      </div>
+  {{ end }}
+{{ end }}

--- a/layouts/partials/i18nlist.html
+++ b/layouts/partials/i18nlist.html
@@ -1,0 +1,9 @@
+{{ if .IsTranslated }}
+<ul class="{{ cond (eq $.Site.Language.LanguageDirection "rtl") "pr0 ml3" "pl0 mr3" }}">
+    {{ range .Translations }}
+    <li class="list f5 f4-ns fw4 dib {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl3" "pr3" }}">
+        <a class="no-underline i18n-link" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+    </li>
+    {{ end}}
+</ul>
+{{ end }}

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -1,0 +1,13 @@
+<footer class="{{ .Site.Params.background_color_class | default "bg-black" }} bottom-0 w-100 pa3 f6" role="contentinfo">
+  <div class="flex-l justify-between">
+    <div>
+      <span id="copyright">&copy; {{ now.Format "2006"}}</span>
+      <span id="cc-license">
+      {{ i18n "CC-BY-NC-SA-License-prefix" }}
+      <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">{{ i18n "CC-BY-NC-SA-License" }}</a>
+      {{ i18n "CC-BY-NC-SA-License-suffix" }}
+    </div>
+    </span>
+    {{ partial "social-follow.html" . }}
+  </div>
+</footer>

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -1,0 +1,48 @@
+{{ $featured_image := partial "func/GetFeaturedImage.html" . }}
+{{ if $featured_image }}
+  {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
+  <header class="cover bg-top" style="background-image: url('{{ $featured_image }}');">
+    <div class="{{ .Site.Params.cover_dimming_class | default "bg-black-60" }}">
+      {{ partial "site-navigation.html" .}}
+      <div class="tc-l pv4 pv6-l ph3 ph4-ns">
+        <h1 class="f2 f-subheadline-l fw2 white-90 mb0 lh-title">
+          {{ .Title | default .Site.Title }}
+        </h1>
+        {{ with .Params.description }}
+          <h2 class="fw1 f5 f3-l white-80 measure-wide-l center mt3">
+            {{ . }}
+          </h2>
+        {{ end }}
+      </div>
+    </div>
+  </header>
+{{ else }}
+  <header>
+    <div class="pb3-m pb6-l {{ .Site.Params.background_color_class | default "bg-black" }}">
+      {{ partial "site-navigation.html" . }}
+      <div class="tc-l pv3 ph3 ph4-ns">
+        <h1 class="f2 f-subheadline-l fw2 light-silver mb0 lh-title">
+          {{ .Title | default .Site.Title }}
+        </h1>
+        {{ with .Params.description }}
+          <h2 class="fw1 f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4">
+            {{ . }}
+          </h2>
+        {{ end }}
+      </div>
+      {{ if (or .IsPage .IsSection) }}
+      {{ else }}
+      <div id="registration" class="tc-l pv3 ph3 ph4-ns">
+        {{ if (isset .Site.Params "registration_url") }}
+          <a href="{{ .Site.Params.registration_url }}" target="_blank">
+            {{- i18n "registration_desc"}}</span>
+        {{ else }}
+          <a href="#" target="_blank" class="disabled-link">
+            {{- i18n "registration_desc"}}<span>{{ i18n "registration_desc_suffix" -}}</span>
+        {{- end -}}
+        </a>
+      </div>
+      {{ end }}
+    </div>
+  </header>
+{{ end }}

--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -1,0 +1,32 @@
+<nav class="pv3 ph3 ph4-ns" role="navigation">
+  <div class="flex-l justify-between items-center center">
+    {{ with .Site.Params.site_logo }}
+    <a href="{{ .Site.Home.RelPermalink }}" class="f3 fw2 no-underline dib">
+      <img src="{{ relURL . }}" class="w100 mw5-ns" alt="{{ $.Site.Title }}" />
+    </a>
+    {{ else }}
+      {{ if (or .IsPage .IsSection) }}
+    <a href="{{ .Site.Home.RelPermalink }}" class="f3 fw2 no-underline dib">
+        {{ .Site.Title }}
+    </a>
+      {{ else }}
+      <span></span>
+      {{ end }}
+    {{ end }}
+    <div class="flex-l items-center nav-right">
+      {{ partial "i18nlist.html" . }}
+      {{ if .Site.Menus.main }}
+        <ul class="{{ cond (eq $.Site.Language.LanguageDirection "rtl") "pr0 ml3" "pl0 mr3" }}">
+          {{ range .Site.Menus.main }}
+          <li class="list f5 f4-ns fw4 dib {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl3" "pr3" }}">
+            <a class="hover-white no-underline white-90" href="{{ .URL }}" title="{{ i18n "pageTitle" . }}">
+              {{ .Name }}
+            </a>
+          </li>
+          {{ end }}
+        </ul>
+      {{ end }}
+      {{ partialCached "social-follow.html" . }}
+    </div>
+  </div>
+</nav>


### PR DESCRIPTION
1. add CC-BY-NC-SA License (with i18n translation files)
2. add a default progressive transition background for header/footer
3. add datetime to summary items in the index page
4. showing language name instead of language code in navigation bar
5. add Github following link
6. display the Table of Contents only when page is wide enough (TODO: show it forever with a sensible layout)
7. add rendering effects to tables in articles
8. append anchored links to each heading in articles
9. add registration button